### PR TITLE
Adding `kcp::KCP::Params::verbose` parameter to toggle logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,23 +41,24 @@ repository. Thank you!
 
 **Table of Contents**
 
-- [:package: Resources](#package-resources)
-- [:gear: Installation](#gear-installation)
-  - [Step 1. Preparing the Dependencies](#step-1-preparing-the-dependencies)
-    - [GCC, CMake, Git, and Eigen3](#gcc-cmake-git-and-eigen3)
-    - [nanoflann](#nanoflann)
-    - [TEASER++](#teaser)
-  - [Step 2. Preparing Dependencies of Python Binding (Optional)](#step-2-preparing-dependencies-of-python-binding-optional)
-  - [Step 3. Building KCP](#step-3-building-kcp)
-    - [Without Python Binding](#without-python-binding)
-    - [With Python Binding](#with-python-binding)
-  - [Step 4. Installing KCP to the System (Optional)](#step-4-installing-kcp-to-the-system-optional)
-- [:seedling: Examples](#seedling-examples)
-- [:memo: Some Remarks](#memo-some-remarks)
-  - [Tuning Parameters](#tuning-parameters)
-  - [Controlling Computational Cost](#controlling-computational-cost)
-  - [Torwarding Global Registration Approaches](#torwarding-global-registration-approaches)
-- [:gift: Acknowledgement](#gift-acknowledgement)
+- [KCP](#kcp)
+  - [:package: Resources](#package-resources)
+  - [:gear: Installation](#gear-installation)
+    - [Step 1. Preparing the Dependencies](#step-1-preparing-the-dependencies)
+      - [GCC, CMake, Git, and Eigen3](#gcc-cmake-git-and-eigen3)
+      - [nanoflann](#nanoflann)
+      - [TEASER++](#teaser)
+    - [Step 2. Preparing Dependencies of Python Binding (Optional)](#step-2-preparing-dependencies-of-python-binding-optional)
+    - [Step 3. Building KCP](#step-3-building-kcp)
+      - [Without Python Binding](#without-python-binding)
+      - [With Python Binding](#with-python-binding)
+    - [Step 4. Installing KCP to the System (Optional)](#step-4-installing-kcp-to-the-system-optional)
+  - [:seedling: Examples](#seedling-examples)
+  - [:memo: Some Remarks](#memo-some-remarks)
+    - [Tuning Parameters](#tuning-parameters)
+    - [Controlling Computational Cost](#controlling-computational-cost)
+    - [Torwarding Global Registration Approaches](#torwarding-global-registration-approaches)
+  - [:gift: Acknowledgement](#gift-acknowledgement)
 
 ## :package: Resources
 
@@ -196,6 +197,9 @@ if a correspondence is correct. In our paper, we suggest `k=2` and `noise_bound`
 the 3-sigma (we use `noise_bound=0.06` meters for nuScenes data), and those are
 default values in the library.
 
+There is also a boolean parameter to enable debug messages called
+`kcp::KCP::Params::verbose` (default: `false`).
+
 To use different parameters to the KCP solver, please refer to the following
 snippets:
 
@@ -207,6 +211,7 @@ snippets:
 auto params = kcp::KCP::Params();
 
 params.k                  = 2;
+params.verbose            = false;
 params.teaser.noise_bound = 0.06;
 
 auto solver = kcp::KCP(params);
@@ -219,6 +224,7 @@ import pykcp
 
 params = pykcp.KCPParams()
 params.k = 2
+params.verbose = False
 params.teaser.noise_bound = 0.06
 
 solver = pykcp.KCP(params)

--- a/docs/remarks.md
+++ b/docs/remarks.md
@@ -13,6 +13,9 @@ if a correspondence is correct. In our paper, we suggest `k=2` and `noise_bound`
 the 3-sigma (we use `noise_bound=0.06` meters for nuScenes data), and those are
 default values in the library.
 
+There is also a boolean parameter to enable debug messages called
+`kcp::KCP::Params::verbose` (default: `false`).
+
 To use different parameters to the KCP solver, please refer to the following
 snippets:
 
@@ -24,6 +27,7 @@ snippets:
 auto params = kcp::KCP::Params();
 
 params.k                  = 2;
+params.verbose            = false;
 params.teaser.noise_bound = 0.06;
 
 auto solver = kcp::KCP(params);
@@ -36,6 +40,7 @@ import pykcp
 
 params = pykcp.KCPParams()
 params.k = 2
+params.verbose = False
 params.teaser.noise_bound = 0.06
 
 solver = pykcp.KCP(params)

--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -87,6 +87,7 @@ int main() {
   auto params = kcp::KCP::Params();
 
   params.k                  = 2;
+  params.verbose            = true;
   params.teaser.noise_bound = 0.06;
 
   auto solver = kcp::KCP(params);

--- a/examples/python/main.py
+++ b/examples/python/main.py
@@ -180,6 +180,7 @@ def main():
     # 3. Estimate the transformation of two clouds with KCP-TEASER.
     params = pykcp.KCPParams()
     params.k = 2
+    params.verbose = True
     params.teaser.noise_bound = 0.06
 
     solver = pykcp.KCP(params)

--- a/kcp/include/kcp/solver.hpp
+++ b/kcp/include/kcp/solver.hpp
@@ -94,11 +94,20 @@ class KCP : public AbstractSolver {
     size_t k;
 
     /**
+     * @brief Enabling debug messages. Default by ``false``.
+     *
+     * @warning It will mute all messages in TEASER++ if it is set to ``false``.
+     *
+     */
+    bool verbose;
+
+    /**
      * @brief Construct a new KCP::Params object.
      * 
      */
     Params() {
       k                                    = 2;
+      verbose                              = false;
       teaser.noise_bound                   = 0.06;
       teaser.cbar2                         = 1;
       teaser.estimate_scaling              = false;

--- a/kcp/src/solver.cpp
+++ b/kcp/src/solver.cpp
@@ -5,6 +5,8 @@
 #include "kcp/solver.hpp"
 #include "kcp/utility.hpp"
 
+#include <iostream>
+
 namespace kcp {
 
 /* ----------------------------------- KCP ---------------------------------- */
@@ -25,8 +27,10 @@ void KCP::solve(const Eigen::MatrixX3d& src,
 
   // Trigger the TEASER++ solver, where the maximum clique pruning will be
   // executed within the solver
+  if (!this->params.verbose) std::cout.setstate(std::ios_base::failbit);
   this->solver.solve(correspondences->points.first,
                      correspondences->points.second);
+  if (!this->params.verbose) std::cout.clear();
 
   // Extract the estimation result
   auto solution                    = this->solver.getSolution();

--- a/python/kcp/wrapper.cpp
+++ b/python/kcp/wrapper.cpp
@@ -70,6 +70,7 @@ PYBIND11_MODULE(pykcp, m) {
   py::class_<kcp::KCP::Params>(m, "KCPParams")
       .def(py::init<>())
       .def_readwrite("k", &kcp::KCP::Params::k)
+      .def_readwrite("verbose", &kcp::KCP::Params::verbose)
       .def_readwrite("teaser", &kcp::KCP::Params::teaser);
 
   py::class_<kcp::KCP>(m, "KCP")


### PR DESCRIPTION
This patch allows users to enable or disable verbose logging in runtime by
setting `kcp::KCP::Params::verbose` to `true` or `false`.

Related issue: #3